### PR TITLE
Fix SDK deprecation

### DIFF
--- a/ios/Classes/SwiftSnapchatFlutterPlugin.swift
+++ b/ios/Classes/SwiftSnapchatFlutterPlugin.swift
@@ -78,9 +78,7 @@ public class SwiftSnapchatFlutterPlugin: NSObject, FlutterPlugin {
     
     
     private func logout(){
-        SCSDKLoginClient.unlinkAllSessions { (isLogout) in
-            print("Logout")
-        }
+        SCSDKLoginClient.clearToken()
     }
     
 }


### PR DESCRIPTION
`SCSDKLoginClient.unlinkAllSessions` is deprecated and throws a build error, since the function no longer exists. See https://github.com/Snapchat/login-kit-sample/issues/9 and https://github.com/Snapchat/login-kit-sample/pull/7. It has been replaced by `clearToken`.